### PR TITLE
Update from update/Mixaster995/test-actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-2
 
 go 1.16
 
-require github.com/Mixaster995/test-actions v0.0.0-20210728052929-6500ffb60792
+require github.com/Mixaster995/test-actions v0.0.0-20210728053657-01d388ed935b

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mixaster995/test-actions v0.0.0-20210728052929-6500ffb60792 h1:dt2K6sO/OVm1+ynvzbq7gEIHRuh2RrCyEDn35T+w+3k=
-github.com/Mixaster995/test-actions v0.0.0-20210728052929-6500ffb60792/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
+github.com/Mixaster995/test-actions v0.0.0-20210728053657-01d388ed935b h1:4pK4Nd4apFvIwzMvac6kiy8l/jwkNJe/xE0Q6m1zMyU=
+github.com/Mixaster995/test-actions v0.0.0-20210728053657-01d388ed935b/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Date: 2021-07-28 05:37:34 +0000
- Update go.mod and go.sum to latest version from Mixaster995/test-actions@main
PR link: https://github.com/Mixaster995/test-actions/pull/
Commit: 01d388e
Author: Mikhail Avramenko
Date: 2021-07-28 12:36:57 +0700
Message:asdfzxcvzxcvwrteqwrtwert