### PR TITLE
Update from update/Mixaster995/test-actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-2
 
 go 1.16
 
-require github.com/Mixaster995/test-actions v0.0.0-20210730035240-0c12cc470fff
+require github.com/Mixaster995/test-actions v0.0.0-20210730061343-3d493aeba850

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mixaster995/test-actions v0.0.0-20210730035240-0c12cc470fff h1:i5819I5JLjYfHWZgNdqryPHlZ4AmrjgJ6R5t5agVvZQ=
-github.com/Mixaster995/test-actions v0.0.0-20210730035240-0c12cc470fff/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
+github.com/Mixaster995/test-actions v0.0.0-20210730061343-3d493aeba850 h1:M+9N3vWMAvoc0pVHVcjHs42cmJMdYrzr8sNjsNqGfZ8=
+github.com/Mixaster995/test-actions v0.0.0-20210730061343-3d493aeba850/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Update go.mod and go.sum to latest version from Mixaster995/test-actions@main
PR link: https://github.com/Mixaster995/test-actions/pull/
Commit: 3d493ae
Author: Mikhail Avramenko
Date: 2021-07-30 13:13:43 +0700
Message:
  - asdfafd