### PR TITLE
Update from update/Mixaster995/test-actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-2
 
 go 1.16
 
-require github.com/Mixaster995/test-actions v0.0.0-20210730062228-be8f0aae7cfe
+require github.com/Mixaster995/test-actions v0.0.0-20210730064009-fa5236e13638

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mixaster995/test-actions v0.0.0-20210730062228-be8f0aae7cfe h1:9F1eslm+/2fQynR0PebusMZMKMM6kZxaEPq7ZjPrq8I=
-github.com/Mixaster995/test-actions v0.0.0-20210730062228-be8f0aae7cfe/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
+github.com/Mixaster995/test-actions v0.0.0-20210730064009-fa5236e13638 h1:tge1yxbtf+GujNrQ2m60Gwq22g2/Twog4O7/NBAQDfg=
+github.com/Mixaster995/test-actions v0.0.0-20210730064009-fa5236e13638/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Update go.mod and go.sum to latest version from Mixaster995/test-actions@main
PR link: https://github.com/Mixaster995/test-actions/pull/
Commit: fa5236e
Author: Авраменко Михаил
Date: 2021-07-30 13:40:09 +0700
Message:
  - Merge pull request #3 from Mixaster995/testing