### PR TITLE
Update from update/Mixaster995/test-actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-2
 
 go 1.16
 
-require github.com/Mixaster995/test-actions v0.0.0-20210730064447-e5452e171587
+require github.com/Mixaster995/test-actions v0.0.0-20210730065700-9cbbf1268b18

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mixaster995/test-actions v0.0.0-20210730064447-e5452e171587 h1:MoDwzZOoXrapdnZzZMC4sBNdqlMAAp1l3gV4dnaZfd4=
-github.com/Mixaster995/test-actions v0.0.0-20210730064447-e5452e171587/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
+github.com/Mixaster995/test-actions v0.0.0-20210730065700-9cbbf1268b18 h1:Xa6JjDZ7lBAd9k+GvapFwBcBNlKsLmlDmSNSg5QxzyU=
+github.com/Mixaster995/test-actions v0.0.0-20210730065700-9cbbf1268b18/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Update go.mod and go.sum to latest version from Mixaster995/test-actions@main
PR link: https://github.com/Mixaster995/test-actions/pull/6
Commit: 9cbbf12
Author: Авраменко Михаил
Date: 2021-07-30 13:57:00 +0700
Message:
  - Merge pull request #6 from Mixaster995/testing2